### PR TITLE
v0.0.4: 깜빡한 `aclocal` 데헷!

### DIFF
--- a/configure
+++ b/configure
@@ -3284,7 +3284,7 @@ fi
 ac_config_headers="$ac_config_headers config.h"
 
 
-
+#AC_CONFIG_MACRO_DIR([m4])
 
 # Checks for programs.
 

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 AC_CONFIG_SRCDIR([src/main_ddakong.c])
 AC_CONFIG_HEADERS([config.h])
 
-AC_CONFIG_MACRO_DIR([m4])
+#AC_CONFIG_MACRO_DIR([m4])
 
 # Checks for programs.
 AC_PROG_CC


### PR DESCRIPTION
ax_check_cflags autoconf-archive 복사하는걸 깜빡했지 뭐야.